### PR TITLE
Allow self update to specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The path where composer will be installed and available to your system. Should b
 
     composer_keep_updated: false
 
-Set this to `true` to update Composer to the latest release every time the playbook is run.
+Set this to `true` to update Composer to the specified `composer_version` or to the latest release every time the playbook is run.
 
     composer_home_path: '~/.composer'
     composer_home_owner: root
@@ -29,11 +29,11 @@ The `COMPOSER_HOME` path and directory ownership; this is the directory where gl
 
     composer_version: ''
 
-You can install a specific release of Composer, e.g. `composer_version: '1.0.0-alpha11'`. If left empty the latest development version will be installed. Note that `composer_keep_updated` will override this variable, as it will always install the latest development version.
+You can install a specific release of Composer, e.g. `composer_version: '1.0.0-alpha11'`. If left empty the latest development version will be installed. Note that `composer_keep_updated` will update to this specific version.
 
     composer_version_branch: '--2'
 
-You can choose which major branch of composer you wish to use. Default is `--2`. Note that `composer_keep_updated` will update the latest version available for this branch.
+You can choose which major branch of composer you wish to use. Default is `--2`. Note that `composer_keep_updated` will update the latest version available for this branch by default if `composer_version` is not defined.
 
     composer_global_packages: []
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,9 @@
     {{ php_executable }} {{ composer_path }} self-update {{ composer_version_branch }}
   register: composer_update
   changed_when: "'Updating to version' in composer_update.stdout"
-  when: composer_keep_updated | bool
+  when:
+    - composer_keep_updated | bool
+    - composer_bin.stat.exists
 
 - name: Ensure composer directory exists.
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,14 +48,15 @@
     creates={{ composer_path }}
   when: not composer_bin.stat.exists
 
-- name: Update Composer to latest version (if configured).
+- name: Update Composer to specific or latest version (if configured).
   command: >
-    {{ php_executable }} {{ composer_path }} self-update {{ composer_version_branch }}
+    {{ php_executable }} {{ composer_path }} self-update {{ composer_version | default(composer_version_branch) }}
   register: composer_update
   changed_when: "'Updating to version' in composer_update.stdout"
   when:
     - composer_keep_updated | bool
     - composer_bin.stat.exists
+    - current_composer_version.stdout != composer_version
 
 - name: Ensure composer directory exists.
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,19 @@
   stat: "path={{ composer_path }}"
   register: composer_bin
 
+- name: Get Composer version if already installed
+  shell: >
+    set -o pipefail;
+    COMPOSER_ALLOW_SUPERUSER=1 {{ php_executable }} {{ composer_path }} --version | cut -f3 -d" "
+  args:
+    executable: /bin/bash
+  failed_when: false
+  changed_when: false
+  register: current_composer_version
+  when:
+    - composer_bin.stat.exists
+    - composer_version is defined
+
 - name: Get Composer installer signature.
   uri:
     url: https://composer.github.io/installer.sig


### PR DESCRIPTION
### Description

The feature allowing to update composer itself already exists but only to the latest version of a major branch.
With this PR, this self-update feature can now update composer to a specific version if defined in `composer_version` variable (last version by default).
This allows to pin and better control the composer version installed.

